### PR TITLE
Log SPA cron errors

### DIFF
--- a/docker/images/spa/crontab
+++ b/docker/images/spa/crontab
@@ -1,3 +1,3 @@
 # An empty line is required at the end of this file for a valid cron file.
-0 0 * * * ansible-playbook --connection=local /ansible/site.yml --vault-password-file /shared/promed_vault_password --extra mongo_url=172.30.2.160:27017 --extra promed_scraper_git_version=ansible-deploy > /cronjob_output.txt
+0 0 * * * ansible-playbook --connection=local /ansible/site.yml --vault-password-file /shared/promed_vault_password --extra mongo_url=172.30.2.160:27017 > /cronjob_output.txt 2> /cronjob_err.txt
 


### PR DESCRIPTION
The cronjob still doesn't seem to be working for SPA. The output file exists but is empty, so I am adding a file for standard error. The promed_scraper_git_version parameter is no longer needed since the branch it points to has been merged.
