### PR TITLE
manually install docker instead of using angstwad.docker.ubuntu

### DIFF
--- a/ansible/main/provision-instance-and-build.yml
+++ b/ansible/main/provision-instance-and-build.yml
@@ -38,8 +38,10 @@
       swapfile_size: 16GB
       swapfile_location: "/swapfile"
       tags: swap
-    - name: angstwad.docker_ubuntu
-      tags: docker
+# Removing angstwad.docker_ubuntu because of bug
+#   now building manually in init/tasks/main.yml
+#    - name: angstwad.docker_ubuntu
+#      tags: docker
     - name: init
       tags: init
     - name: build-image

--- a/ansible/main/roles/init/tasks/main.yml
+++ b/ansible/main/roles/init/tasks/main.yml
@@ -6,8 +6,10 @@
     - python-pip
     - python-dev
     - curl
+    - python-setuptools
     # In case ansible is running through python3
     - python3-pip
+    - python3-setuptools
 - name: Install global python modules
   pip:
     name:
@@ -20,6 +22,22 @@
   file: path=~/.aws state=directory
 - name: Create aws credentials
   template: src=config.j2 dest=~/.aws/config
+- name: add docker gpg apt key
+  apt_key:
+    url: https://download.docker.com/linux/ubuntu/gpg
+    state: present
+- name: add docker repo
+  apt_repository:
+    repo: deb https://download.docker.com/linux/ubuntu bionic stable
+    state: present
+- name: update apt and install docker-ce
+  apt: update_cache=yes name=docker-ce state=present
+- name: install Docker module for Python
+  pip:
+    name:
+      - docker
+      - docker-compose
+
 - block:
     - name: Add Mongo packages repo
       apt_key: id=0C49F3730359A14518585931BC711F9BA15703C6  keyserver=keyserver.ubuntu.com


### PR DESCRIPTION
I just started getting an error from the angstwad.docker.ubuntu package we use to install docker, so I'm no longer able to build and deploy the WABNET website.  I think the fix in this branch will install manually, which isn't as much work as it used to  be.  angstwad.docker.ubuntu is no longer used by its developer and is no longer being maintained (https://github.com/angstwad/docker.ubuntu/issues/240).

Please let me know if you think there's a better solution and let's please discuss further if you have time.

Here's a copy of the error message:
TASK [angstwad.docker_ubuntu : Clean previous docker-py package if installing docker.] ***
Tuesday 26 January 2021  20:35:06 +0000 (0:00:00.048)       0:00:56.886 ******* 
fatal: [54.91.16.235]: FAILED! => {"changed": false, "cmd": ["/usr/local/bin/pip3", "uninstall", "-y", "docker-py"], "msg": "\n:stderr: Traceback (most recent call last):\n  File \"/usr/local/bin/pip3\", line 7, in <module>\n    from pip._internal.cli.main import main\n  File \"/usr/local/lib/python3.5/dist-packages/pip/_internal/cli/main.py\", line 60\n    sys.stderr.write(f\"ERROR: {exc}\")\n                                   ^\nSyntaxError: invalid syntax\n"}
	to retry, use: --limit @/opt/infrastructure/ansible/main/provision-instance-and-build.retry

PLAY RECAP *********************************************************************
54.91.16.235               : ok=19   changed=2    unreachable=0    failed=1   
localhost                  : ok=8    changed=3    unreachable=0    failed=0   

Tuesday 26 January 2021  20:35:06 +0000 (0:00:00.460)       0:00:57.347 ******* 
=============================================================================== 
provision-instances : Install AWS CLI ---------------------------------- 22.48s
provision-instances : Wait for the instances to boot by checking the ssh ports --- 8.35s
Gathering Facts --------------------------------------------------------- 6.35s
provision-instances : Provision an AWS instance ------------------------- 2.50s
provision-instances : Wait a couple seconds in case instance is not ready to accept connections --- 2.06s
provision-instances : Install boto via PIP ------------------------------ 2.02s
Gathering Facts --------------------------------------------------------- 2.00s
angstwad.docker_ubuntu : Install dmsetup for Ubuntu 16.04 --------------- 1.65s
angstwad.docker_ubuntu : HTTPS APT transport for Docker repository ------ 0.84s
angstwad.docker_ubuntu : Ensure GNUPG-curl is available for https ------- 0.82s
angstwad.docker_ubuntu : Install python3-dev, python3-pip packages with apt --- 0.77s
angstwad.docker_ubuntu : Install (or update) docker package ------------- 0.77s
angstwad.docker_ubuntu : Add Docker repository key ---------------------- 0.65s
angstwad.docker_ubuntu : Add Docker repository and update apt cache ----- 0.57s
provision-instances : Check whether pip is installed -------------------- 0.55s
kamaln7.swapfile : Set swapfile permissions ----------------------------- 0.48s
kamaln7.swapfile : Add swapfile to /etc/fstab --------------------------- 0.47s
angstwad.docker_ubuntu : Clean previous docker-py package if installing docker. --- 0.46s
Cancel prior shutdown commands ------------------------------------------ 0.36s
kamaln7.swapfile : Write swapfile --------------------------------------- 0.36s
Build step 'Execute shell' marked build as failure
Finished: FAILURE